### PR TITLE
Change source of svox repo to AOSP

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -310,7 +310,7 @@
   <project path="external/stressapptest" name="CyanogenMod/android_external_stressapptest" />
   <project path="external/square/dagger" name="CyanogenMod/android_external_square_dagger" />
   <project path="external/square/javawriter" name="CyanogenMod/android_external_square_javawriter" />
-  <project path="external/svox" name="CyanogenMod/android_external_svox" />
+  <project path="external/svox" name="platform/external/svox" remote="aosp" revision="refs/tags/android-4.4.4_r2" />
   <project path="external/tagsoup" name="CyanogenMod/android_external_tagsoup" />
   <project path="external/tcpdump" name="CyanogenMod/android_external_tcpdump" />
   <project path="external/timezonepicker-support" name="platform/external/timezonepicker-support" remote="aosp" revision="refs/tags/android-4.4.4_r2" />


### PR DESCRIPTION
Svox has been removed from Cyanogenmod due to license infringement, switch to AOSP
